### PR TITLE
Set publishing.channel_id to the ID, not the name

### DIFF
--- a/superform/superform/__init__.py
+++ b/superform/superform/__init__.py
@@ -41,7 +41,7 @@ def index():
         setattr(user,'is_mod',is_moderator(user))
         posts = db.session.query(Post).filter(Post.user_id==session.get("user_id", ""))
         chans = get_moderate_channels_for_user(user)
-        pubs_per_chan = (db.session.query(Publishing).filter((Publishing.channel_id == c.name) & (Publishing.state == 0)) for c in chans)
+        pubs_per_chan = (db.session.query(Publishing).filter((Publishing.channel_id == c.id) & (Publishing.state == 0)) for c in chans)
         flattened_list_pubs = [y for x in pubs_per_chan for y in x]
 
     return render_template("index.html", user=user,posts=posts,publishings = flattened_list_pubs)

--- a/superform/superform/posts.py
+++ b/superform/superform/posts.py
@@ -33,7 +33,7 @@ def create_a_publishing(post, chn, form):
         form.get(chan + '_datefrompost')) is not None else post.date_from
     date_until = datetime_converter(form.get(chan + '_dateuntilpost')) if datetime_converter(
         form.get(chan + '_dateuntilpost')) is not None else post.date_until
-    pub = Publishing(post_id=post.id, channel_id=chan, state=0, title=title_post, description=descr_post,
+    pub = Publishing(post_id=post.id, channel_id=chn.id, state=0, title=title_post, description=descr_post,
                      link_url=link_post, image_url=image_post,
                      date_from=date_from, date_until=date_until)
 

--- a/superform/superform/posts.py
+++ b/superform/superform/posts.py
@@ -33,7 +33,7 @@ def create_a_publishing(post, chn, form):
         form.get(chan + '_datefrompost')) is not None else post.date_from
     date_until = datetime_converter(form.get(chan + '_dateuntilpost')) if datetime_converter(
         form.get(chan + '_dateuntilpost')) is not None else post.date_until
-    pub = Publishing(post_id=post.id, channel_id=chn.id, state=0, title=title_post, description=descr_post,
+    pub = Publishing(post_id=post.id, channel_id=chan.id, state=0, title=title_post, description=descr_post,
                      link_url=link_post, image_url=image_post,
                      date_from=date_from, date_until=date_until)
 

--- a/superform/superform/publishings.py
+++ b/superform/superform/publishings.py
@@ -23,7 +23,7 @@ def moderate_publishing(id,idc):
         pub.state = 1
         db.session.commit()
         #running the plugin here
-        c=db.session.query(Channel).filter(Channel.name == pub.channel_id).first()
+        c=db.session.query(Channel).filter(Channel.id == pub.channel_id).first()
         plugin_name = c.module
         c_conf = c.config
         from importlib import import_module

--- a/superform/superform/templates/index.html
+++ b/superform/superform/templates/index.html
@@ -34,7 +34,7 @@
                 {% for p in publishings %}
                     <tr>
                         <td>
-                            {{ p.channel_id }}
+                            {{ p.channel.name }}
                         </td>
                         <td>
                             {{ p.title }}


### PR DESCRIPTION
When creating a publishing, the 'channel_id' column of the 'publishing' table was being set to the channel's name, not its ID. This commit fixes that.

This was problematic as you couldn't filter publishings based on the channel ID.