### PR TITLE
Fix: Moderate post with channel not configured

### DIFF
--- a/superform/superform/channels.py
+++ b/superform/superform/channels.py
@@ -1,3 +1,5 @@
+import json
+
 from flask import Blueprint, current_app, url_for, request, make_response, redirect, session, render_template
 
 from superform.utils import login_required, get_instance_from_module_path, get_modules_names, get_module_full_name
@@ -5,6 +7,14 @@ from superform.models import db, Channel
 import ast
 
 channels_page = Blueprint('channels', __name__)
+
+
+def valid_conf(config, fields):
+    config_json = json.loads(config)
+    for field in fields:
+        if field not in config_json:
+            return False
+    return True
 
 
 @channels_page.route("/channels", methods=['GET', 'POST'])

--- a/superform/superform/templates/index.html
+++ b/superform/superform/templates/index.html
@@ -4,7 +4,6 @@
     <h1>Index</h1>
 
     {% if session.logged_in %}
-
         <div class="row">
         <div class="col-md-12">
             {% if user.is_mod %}

--- a/superform/superform/templates/moderate_post.html
+++ b/superform/superform/templates/moderate_post.html
@@ -3,44 +3,48 @@
 {% block content %}
     <h1>Moderate this publication</h1>
     {% if session.logged_in %}
-        <form method="POST" action="">
-            <div class="row">
-                <div class="col-md-12">
-                    <div class="form-group">
-                        <label for="titlepost">Title</label><br>
-                        <input type="text" name="titlepost" id="titlepost" class="form-control" value="{{ pub.title }}">
-                    </div>
-                    <div class="form-group">
-                        <label for="descrpost">Description</label><br>
-                        <textarea class="form-control" rows="5" id="descrpost" name="descrpost">{{ pub.description }}</textarea>
-                    </div>
-                    <div class="form-group">
-                        <label for="linkurlpost">Link</label><br>
-                        <input type="text" name="linkurlpost" id="linkurlpost" class="form-control" value="{{ pub.link_url }}">
-                    </div>
-                    <div class="form-group">
-                        <label for="imagepost">Image</label><br>
-                        <input type="file" name="imagepost" id="imagepost" class="form-control" value="{{ pub.image_url }}">
-                    </div>
-                    <div class="row">
-                        <div class="col-md-6">
-                            <div class="form-group">
-                                <label for="datefrompost">Publication Date</label><br>
-                                <input id="datefrompost" name="datefrompost" type="date" class="form-control" value="{{ pub.date_from }}">
+        {% if pub %}
+            <form method="POST" action="">
+                <div class="row">
+                    <div class="col-md-12">
+                        <div class="form-group">
+                            <label for="titlepost">Title</label><br>
+                            <input type="text" name="titlepost" id="titlepost" class="form-control" value="{{ pub.title }}">
+                        </div>
+                        <div class="form-group">
+                            <label for="descrpost">Description</label><br>
+                            <textarea class="form-control" rows="5" id="descrpost" name="descrpost">{{ pub.description }}</textarea>
+                        </div>
+                        <div class="form-group">
+                            <label for="linkurlpost">Link</label><br>
+                            <input type="text" name="linkurlpost" id="linkurlpost" class="form-control" value="{{ pub.link_url }}">
+                        </div>
+                        <div class="form-group">
+                            <label for="imagepost">Image</label><br>
+                            <input type="file" name="imagepost" id="imagepost" class="form-control" value="{{ pub.image_url }}">
+                        </div>
+                        <div class="row">
+                            <div class="col-md-6">
+                                <div class="form-group">
+                                    <label for="datefrompost">Publication Date</label><br>
+                                    <input id="datefrompost" name="datefrompost" type="date" class="form-control" value="{{ pub.date_from }}">
+                                </div>
+                            </div>
+                            <div class="col-md-6">
+                                <div class="form-group">
+                                    <label for="dateuntilpost">Publication Until</label><br>
+                                    <input id="dateuntilpost" name="dateuntilpost" type="date" class="form-control" value="{{ pub.date_until }}">
+                                </div>
                             </div>
                         </div>
-                        <div class="col-md-6">
-                            <div class="form-group">
-                                <label for="dateuntilpost">Publication Until</label><br>
-                                <input id="dateuntilpost" name="dateuntilpost" type="date" class="form-control" value="{{ pub.date_until }}">
-                            </div>
-                        </div>
-                    </div>
 
+                    </div>
                 </div>
-            </div>
-            <button class="btn btn-success">Publish</button>
-        </form>
+                <button class="btn btn-success">Publish</button>
+            </form>
+        {% else %}
+            The channel is not yet properly configured for publishing.
+        {% endif %}
     {% else %}
         Your are not logged in.
     {% endif %}

--- a/superform/superform/templates/moderate_post.html
+++ b/superform/superform/templates/moderate_post.html
@@ -3,48 +3,48 @@
 {% block content %}
     <h1>Moderate this publication</h1>
     {% if session.logged_in %}
-        {% if pub %}
-            <form method="POST" action="">
-                <div class="row">
-                    <div class="col-md-12">
-                        <div class="form-group">
-                            <label for="titlepost">Title</label><br>
-                            <input type="text" name="titlepost" id="titlepost" class="form-control" value="{{ pub.title }}">
-                        </div>
-                        <div class="form-group">
-                            <label for="descrpost">Description</label><br>
-                            <textarea class="form-control" rows="5" id="descrpost" name="descrpost">{{ pub.description }}</textarea>
-                        </div>
-                        <div class="form-group">
-                            <label for="linkurlpost">Link</label><br>
-                            <input type="text" name="linkurlpost" id="linkurlpost" class="form-control" value="{{ pub.link_url }}">
-                        </div>
-                        <div class="form-group">
-                            <label for="imagepost">Image</label><br>
-                            <input type="file" name="imagepost" id="imagepost" class="form-control" value="{{ pub.image_url }}">
-                        </div>
-                        <div class="row">
-                            <div class="col-md-6">
-                                <div class="form-group">
-                                    <label for="datefrompost">Publication Date</label><br>
-                                    <input id="datefrompost" name="datefrompost" type="date" class="form-control" value="{{ pub.date_from }}">
-                                </div>
-                            </div>
-                            <div class="col-md-6">
-                                <div class="form-group">
-                                    <label for="dateuntilpost">Publication Until</label><br>
-                                    <input id="dateuntilpost" name="dateuntilpost" type="date" class="form-control" value="{{ pub.date_until }}">
-                                </div>
+        {% if conf %}
+            <div class="alert alert-danger" role="alert">
+                This channel is not yet configured
+            </div>
+        {% endif %}
+        <form method="POST" action="">
+            <div class="row">
+                <div class="col-md-12">
+                    <div class="form-group">
+                        <label for="titlepost">Title</label><br>
+                        <input type="text" name="titlepost" id="titlepost" class="form-control" value="{{ pub.title }}">
+                    </div>
+                    <div class="form-group">
+                        <label for="descrpost">Description</label><br>
+                        <textarea class="form-control" rows="5" id="descrpost" name="descrpost">{{ pub.description }}</textarea>
+                    </div>
+                    <div class="form-group">
+                        <label for="linkurlpost">Link</label><br>
+                        <input type="text" name="linkurlpost" id="linkurlpost" class="form-control" value="{{ pub.link_url }}">
+                    </div>
+                    <div class="form-group">
+                        <label for="imagepost">Image</label><br>
+                        <input type="file" name="imagepost" id="imagepost" class="form-control" value="{{ pub.image_url }}">
+                    </div>
+                    <div class="row">
+                        <div class="col-md-6">
+                            <div class="form-group">
+                                <label for="datefrompost">Publication Date</label><br>
+                                <input id="datefrompost" name="datefrompost" type="date" class="form-control" value="{{ pub.date_from }}">
                             </div>
                         </div>
-
+                        <div class="col-md-6">
+                            <div class="form-group">
+                                <label for="dateuntilpost">Publication Until</label><br>
+                                <input id="dateuntilpost" name="dateuntilpost" type="date" class="form-control" value="{{ pub.date_until }}">
+                            </div>
+                        </div>
                     </div>
                 </div>
-                <button class="btn btn-success">Publish</button>
-            </form>
-        {% else %}
-            The channel is not yet properly configured for publishing.
-        {% endif %}
+            </div>
+            <button class="btn btn-success" {% if conf %} disabled {% endif %}>Publish</button>
+        </form>
     {% else %}
         Your are not logged in.
     {% endif %}


### PR DESCRIPTION
If a channel was not yet configured and a moderator wanted to moderate a
post to this channel, an error 500 was raised because the config field of
the channel in the database was empty.