### PR TITLE
Fix: deleting a channel with published posts fails.

### DIFF
--- a/superform/superform/models.py
+++ b/superform/superform/models.py
@@ -75,7 +75,7 @@ class Channel(db.Model):
     module = db.Column(db.String(100), nullable=False)
     config = db.Column(db.Text, nullable=False)
 
-    publishings = db.relationship("Publishing", backref="channel", lazy=True)
+    publishings = db.relationship("Publishing", cascade="all, delete-orphan", backref="channel", lazy=True)
     authorizations = db.relationship("Authorization", cascade="all, delete", backref="channel", lazy=True)
 
     __table_args__ = ({"sqlite_autoincrement": True},)


### PR DESCRIPTION
Now, the publishings are (logically) also cascade-deleted.