### PR TITLE
Create new tab to render all posts

### DIFF
--- a/superform/superform/__init__.py
+++ b/superform/superform/__init__.py
@@ -39,12 +39,14 @@ def index():
     flattened_list_pubs =[]
     if user is not None:
         setattr(user,'is_mod',is_moderator(user))
-        posts = db.session.query(Post).filter(Post.user_id==session.get("user_id", ""))
+        from sqlalchemy import desc
+        posts = db.session.query(Post).filter(Post.user_id == session.get("user_id", "")).order_by(desc(Post.id)).limit(5).all()
         chans = get_moderate_channels_for_user(user)
         pubs_per_chan = (db.session.query(Publishing).filter((Publishing.channel_id == c.id) & (Publishing.state == 0)) for c in chans)
         flattened_list_pubs = [y for x in pubs_per_chan for y in x]
 
-    return render_template("index.html", user=user,posts=posts,publishings = flattened_list_pubs)
+    return render_template("index.html", user=user, posts=posts, publishings=flattened_list_pubs)
+
 
 @app.errorhandler(403)
 def forbidden(error):

--- a/superform/superform/posts.py
+++ b/superform/superform/posts.py
@@ -63,6 +63,14 @@ def publish_from_new_post():
     return redirect(url_for('index'))
 
 
+@posts_page.route('/list_posts', methods=['GET'])
+@login_required()
+def get_all_posts():
+    from sqlalchemy import desc
+    posts = db.session.query(Post).filter(Post.user_id == session.get("user_id", "")).order_by(desc(Post.id))
+    return render_template('list_posts.html', posts=posts)
+
+
 @posts_page.route('/records')
 @login_required()
 def records():

--- a/superform/superform/templates/index.html
+++ b/superform/superform/templates/index.html
@@ -91,7 +91,7 @@
                     <td>
                         <a href="#" class="btn btn-outline-primary" role="button">Edit</a>
                         <a href="#" class="btn btn-outline-primary">Copy</a>
-                        <a href="#" class="btn btn-outline-warning" role="button">Delete</a>
+                        <a href="#" class="btn btn-outline-danger" role="button">Delete</a>
                     </td>
                 </tr>
                 {% endfor %}

--- a/superform/superform/templates/layout.html
+++ b/superform/superform/templates/layout.html
@@ -33,6 +33,9 @@
                             <a class="nav-link" href="{{ url_for('posts.new_post')}}">New post</a>
                         </li>
                         <li class="nav-item">
+                            <a class="nav-link" href="{{ url_for('posts.get_all_posts') }}">All my posts</a>
+                        </li>
+                        <li class="nav-item">
                             <a class="nav-link" href="{{ url_for('posts.records')}}">Archives</a>
                         </li>
                         <li class="nav-item {{ 'active' if request.endpoint == 'authorizations.authorizations' else '' }}">

--- a/superform/superform/templates/list_posts.html
+++ b/superform/superform/templates/list_posts.html
@@ -50,7 +50,7 @@
                         <td>
                             <button type="button" class="btn btn-outline-primary" contenteditable="true">Edit</button>
                             <button type="button" class="btn btn-outline-primary" contenteditable="true">Copy</button>
-                            <button type="button" class="btn btn-outline-primary" contenteditable="true">Delete</button>
+                            <button type="button" class="btn btn-outline-danger" contenteditable="true">Delete</button>
                         </td>
                     </tr>
                 {% endfor %}

--- a/superform/superform/templates/list_posts.html
+++ b/superform/superform/templates/list_posts.html
@@ -1,0 +1,61 @@
+{% extends "layout.html" %}
+{% block title %}Superform - All my posts{% endblock %}
+{% block styles %}
+    {{super()}}
+    <link rel="stylesheet"
+          href="{{url_for('static', filename='css/style.css')}}">
+{% endblock %}
+{% block scripts %}
+    <!--<script src="{{url_for('static', filename='js/script.js')}}"></script>-->
+    {{super()}}
+{% endblock %}
+
+
+
+
+
+{% block content %}
+    <h1>All my posts</h1>
+    <div class="row">
+        <div class="col-md-12">
+            <table class="table table-bordered">
+                <thead>
+                <tr>
+                    <th>
+                        #
+                    </th>
+                    <th>
+                        Subject
+                    </th>
+                    <th>
+                        Body
+                    </th>
+                    <th>
+                        Action
+                    </th>
+                </tr>
+                </thead>
+                <tbody>
+                {% for p in posts %}
+                    <tr>
+                        <td>
+                            {{ p.id }}
+                        </td>
+                        <td>
+                            {{ p.title }}
+                        </td>
+                        <td>
+                            {{ p.description }}
+                        </td>
+                        <td>
+                            <button type="button" class="btn btn-outline-primary" contenteditable="true">Edit</button>
+                            <button type="button" class="btn btn-outline-primary" contenteditable="true">Copy</button>
+                            <button type="button" class="btn btn-outline-primary" contenteditable="true">Delete</button>
+                        </td>
+                    </tr>
+                {% endfor %}
+                </tbody>
+            </table>
+        </div>
+    </div>
+{% endblock %}


### PR DESCRIPTION
It is fine to have the 5 last posts written in the home page but
rendering all the posts could be painful to watch (after some years of
publishing an author can easily have 100 posts)... So I made a new
tab "All my posts" at /list_posts that renders all the posts (in descending order since we usually want to see the latest posts written) and limit the number of posts on the home page to 5 (in descending order also).