### PR TITLE
Allow plugins to insert customised html and js in forms

### DIFF
--- a/superform/superform/publishings.py
+++ b/superform/superform/publishings.py
@@ -31,7 +31,7 @@ def create_a_publishing(post, chn, form):
 @login_required()
 def moderate_publishing(id, idc):
     pub = db.session.query(Publishing).filter(Publishing.post_id == id, Publishing.channel_id == idc).first()
-    c = db.session.query(Channel).filter(Channel.id == pub.channel_id).first()
+    c = db.session.query(Channel).filter(Channel.id == idc).first()
     pub.date_from = str_converter(pub.date_from)
     pub.date_until = str_converter(pub.date_until)
 
@@ -42,9 +42,9 @@ def moderate_publishing(id, idc):
 
     if request.method == "GET":
         if channels.valid_conf(c_conf, plugin.CONFIG_FIELDS):
-            return render_template('moderate_post.html', pub=pub, notconf=False)
+            return render_template('moderate_post.html', pub=pub, notconf=False, chan=c)
         else:
-            return render_template('moderate_post.html', pub=pub, notconf=True)
+            return render_template('moderate_post.html', pub=pub, notconf=True, chan=c)
     else:
         pub.title = request.form.get('titlepost')
         pub.description = request.form.get('descrpost')
@@ -60,7 +60,7 @@ def moderate_publishing(id, idc):
             # running the plugin here
             plugin.run(pub, c_conf)
         else:
-            return render_template('moderate_post.html', pub=pub, notconf=True)
+            return render_template('moderate_post.html', pub=pub, notconf=True, chan=c)
 
         return redirect(url_for('index'))
 

--- a/superform/superform/templates/moderate_post.html
+++ b/superform/superform/templates/moderate_post.html
@@ -41,9 +41,11 @@
                             </div>
                         </div>
                     </div>
-                    {% set module_name = chan.module.split('.')[2].lower() %}
-                    {% set template = 'plugins/' + module_name + '/moderate.html' %}
-                    {% include template ignore missing %}
+                    {% if chan %}
+                        {% set module_name = chan.module.split('.')[2].lower() %}
+                        {% set template = 'plugins/' + module_name + '/moderate.html' %}
+                        {% include template ignore missing %}
+                    {% endif %}
                 </div>
             </div>
             <button class="btn btn-success" {% if notconf %} disabled {% endif %}>Publish</button>
@@ -55,9 +57,11 @@
 {% endblock %}
 {% block scripts %}
     <script>
-        {% set module_name = chan.module.split('.')[2].lower() %}
-        {% set template = 'plugins/' + module_name + '/moderate.js'%}
-        {% include template ignore missing %}
+        {% if chan %}
+            {% set module_name = chan.module.split('.')[2].lower() %}
+            {% set template = 'plugins/' + module_name + '/moderate.js'%}
+            {% include template ignore missing %}
+        {% endif %}
     </script>
 
 {% endblock %}

--- a/superform/superform/templates/moderate_post.html
+++ b/superform/superform/templates/moderate_post.html
@@ -41,6 +41,9 @@
                             </div>
                         </div>
                     </div>
+                    {% set module_name = chan.module.split('.')[2].lower() %}
+                    {% set template = 'plugins/' + module_name + '/moderate.html' %}
+                    {% include template ignore missing %}
                 </div>
             </div>
             <button class="btn btn-success" {% if notconf %} disabled {% endif %}>Publish</button>
@@ -48,5 +51,13 @@
     {% else %}
         Your are not logged in.
     {% endif %}
+
+{% endblock %}
+{% block scripts %}
+    <script>
+        {% set module_name = chan.module.split('.')[2].lower() %}
+        {% set template = 'plugins/' + module_name + '/moderate.js'%}
+        {% include template ignore missing %}
+    </script>
 
 {% endblock %}

--- a/superform/superform/templates/new.html
+++ b/superform/superform/templates/new.html
@@ -52,7 +52,6 @@
                                         </div>
                                     </div>
                                 </div>
-
                             </div>
                         </div>
                     </div>
@@ -120,7 +119,9 @@
                                         </div>
                                     </div>
                                 </div>
-
+                                {% set module_name = chan.module.split('.')[2].lower() %}
+                                {% set template = 'plugins/' + module_name + '/new.html' %}
+                                {% include template ignore missing %}
                             </div>
                         </div>
                     </div>
@@ -212,6 +213,11 @@
                 $('#li_'+nameC).hide();
             }
         });
+        {% for chan in l_chan %}
+            {% set module_name = chan.module.split('.')[2].lower() %}
+            {% set template = 'plugins/' + module_name + '/new.js'%}
+            {% include template ignore missing %}
+        {% endfor %}
     </script>
 
 {% endblock %}


### PR DESCRIPTION
Adds to moderate_post.html and new.html the possiblity for a plugin to add easily some html to. To add specific fields or behaviour for your module in new or moderate_post you should create a folder in templates/plugins with the name of your plugin. Inside that folder you should create a file named moderate.html (or/and new.html if you want to add some stuff when creating a new post). Same if you want to add some personlised scripts. Make a file in the same directory (templates/plugins/plugin_name/) with the name moderate.js (or/and new.js).

If you want to add this feature to new templates you can juste add the same modifications than in new.html and moderate_post.html. Add then in the plugin folder of your module the file with the corresponding name. Don't forget to make sure that you pass the channel in argument when calling the template.

The place where the plugin stuff will be added is for now below data_until, it can maybe be moved above.

Co-authored-by: Maxmaw <maxime.mawait@student.uclouvain.be>
Co-authored-by: Sami <sami.bosch@student.uclouvain.be>
Co-authored-by: bensim602 <benjamin.simon@student.uclouvain.be>
Co-authored-by: sluyters <arthur.sluyters@student.uclouvain.be>
Co-authored-by: Gui <guillaume.gheysen@student.uclouvain.be>
Co-authored-by: TGLuis <luis.tascon@student.uclouvain.be>
Co-authored-by: tanguyl <tanguy.losseau@student.uclouvain.be>